### PR TITLE
Fix: 가족 전체 조회 + 그룹 이름 조회

### DIFF
--- a/src/main/java/da_ni_ni/backend/emotion/controller/EmotionController.java
+++ b/src/main/java/da_ni_ni/backend/emotion/controller/EmotionController.java
@@ -3,6 +3,8 @@ package da_ni_ni.backend.emotion.controller;
 import da_ni_ni.backend.common.ResponseDto;
 import da_ni_ni.backend.emotion.dto.*;
 import da_ni_ni.backend.emotion.service.EmotionService;
+import da_ni_ni.backend.group.dto.UpdateGroupNameRequest;
+import da_ni_ni.backend.group.dto.UpdateGroupNameResponse;
 import da_ni_ni.backend.user.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -66,6 +68,16 @@ public class EmotionController {
         log.info("Request to PUT update other member nickname");
         Long userId = authService.getCurrentUser().getId();
         UpdateNicknameResponse response = emotionService.updateOtherMemberNickname(request, emotionId, userId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    // 그룹명 수정
+    @PutMapping("/group/{groupId}/groupname")
+    private ResponseEntity<ResponseDto> updateGroupName (
+            @RequestBody UpdateGroupNameRequest request) {
+        log.info("Request to PUT familyGroup name");
+        Long userId = authService.getCurrentUser().getId();
+        UpdateGroupNameResponse response =emotionService.updateGroupName(userId, request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/da_ni_ni/backend/emotion/dto/FindTotalEmotionsResponse.java
+++ b/src/main/java/da_ni_ni/backend/emotion/dto/FindTotalEmotionsResponse.java
@@ -3,6 +3,7 @@ package da_ni_ni.backend.emotion.dto;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import da_ni_ni.backend.common.ResponseDto;
+import da_ni_ni.backend.group.domain.FamilyGroup;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,10 +13,13 @@ import java.util.List;
 @Builder
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class FindTotalEmotionsResponse implements ResponseDto {
+    private String groupName;
     private List<FindEmotionDetailResponse> emotionList;
 
-    public static FindTotalEmotionsResponse createWith(List<FindEmotionDetailResponse> emotionList) {
+    public static FindTotalEmotionsResponse createWith(FamilyGroup familyGroup
+                                                       , List<FindEmotionDetailResponse> emotionList) {
         return FindTotalEmotionsResponse.builder()
+                .groupName(familyGroup.getName())
                 .emotionList(emotionList)
                 .build();
     }

--- a/src/main/java/da_ni_ni/backend/emotion/service/EmotionService.java
+++ b/src/main/java/da_ni_ni/backend/emotion/service/EmotionService.java
@@ -4,6 +4,10 @@ import da_ni_ni.backend.emotion.domain.Emotion;
 import da_ni_ni.backend.emotion.dto.*;
 import da_ni_ni.backend.emotion.exception.EmotionNotFoundException;
 import da_ni_ni.backend.emotion.repository.EmotionRepository;
+import da_ni_ni.backend.group.domain.FamilyGroup;
+import da_ni_ni.backend.group.dto.UpdateGroupNameData;
+import da_ni_ni.backend.group.dto.UpdateGroupNameRequest;
+import da_ni_ni.backend.group.dto.UpdateGroupNameResponse;
 import da_ni_ni.backend.group.exception.GroupNotFoundException;
 import da_ni_ni.backend.group.repository.GroupRepository;
 import da_ni_ni.backend.user.domain.User;
@@ -96,7 +100,10 @@ public class EmotionService {
                 .map(FindEmotionDetailResponse::createWith)
                 .collect(Collectors.toList());
 
-        return FindTotalEmotionsResponse.createWith(emotionList);
+        FamilyGroup groupName = groupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+
+        return FindTotalEmotionsResponse.createWith(groupName, emotionList);
     }
 
     // 다른 구성원 닉네임 수정
@@ -113,6 +120,20 @@ public class EmotionService {
         }
         targetUser.updateNickname(nickName);
         return UpdateNicknameResponse.createWith(emotion);
+    }
+
+    // 가족명 수정 (O)
+    public UpdateGroupNameResponse updateGroupName(Long userId, UpdateGroupNameRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        FamilyGroup familyGroup = user.getFamilyGroup();
+        if (familyGroup == null) {
+            throw new GroupNotFoundException();
+        }
+        UpdateGroupNameData updateGroupNameData = UpdateGroupNameData.createWith(request);
+        familyGroup.updateName(updateGroupNameData);
+        groupRepository.save(familyGroup);
+        return UpdateGroupNameResponse.createWith(familyGroup);
     }
 
 }

--- a/src/main/java/da_ni_ni/backend/emotion/service/EmotionService.java
+++ b/src/main/java/da_ni_ni/backend/emotion/service/EmotionService.java
@@ -136,5 +136,6 @@ public class EmotionService {
         return UpdateGroupNameResponse.createWith(familyGroup);
     }
 
+
 }
 

--- a/src/main/java/da_ni_ni/backend/group/controller/GroupController.java
+++ b/src/main/java/da_ni_ni/backend/group/controller/GroupController.java
@@ -67,13 +67,4 @@ public class GroupController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    // 그룹명 수정
-    @PutMapping
-    private ResponseEntity<ResponseDto> updateGroupName (
-            @RequestBody UpdateGroupNameRequest request) {
-        log.info("Request to PUT familyGroup name");
-        Long userId = authService.getCurrentUser().getId();
-        UpdateGroupNameResponse response = groupService.updateGroupName(userId, request);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
 }

--- a/src/main/java/da_ni_ni/backend/group/repository/GroupRepository.java
+++ b/src/main/java/da_ni_ni/backend/group/repository/GroupRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<FamilyGroup, Long> {
     boolean existsByAdminUser(User user);
+    Optional<FamilyGroup>findById(Long id);
     Optional<FamilyGroup>findByInviteCode(String inviteCode);
     Optional<FamilyGroup>findByAdminUser(User user);
 }

--- a/src/main/java/da_ni_ni/backend/group/service/GroupService.java
+++ b/src/main/java/da_ni_ni/backend/group/service/GroupService.java
@@ -124,19 +124,4 @@ public class GroupService {
         return ApprovejoinResponse.createWith(targetRequest);
     }
 
-    // 가족명 수정 (O)
-    public UpdateGroupNameResponse updateGroupName(Long userId, UpdateGroupNameRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-        FamilyGroup familyGroup = user.getFamilyGroup();
-        if (familyGroup == null) {
-            throw new GroupNotFoundException();
-        }
-        UpdateGroupNameData updateGroupNameData = UpdateGroupNameData.createWith(request);
-        familyGroup.updateName(updateGroupNameData);
-        groupRepository.save(familyGroup);
-        return UpdateGroupNameResponse.createWith(familyGroup);
-    }
-
-
 }


### PR DESCRIPTION
- GroupService, GroupController에 있던 그룹 이름 수정 로직도 EmotionService, EmotionController로 이동
- 그룹 이름 조회 Url (/groups)에서 (/emotions/group/{groupId}/groupName/)으로 변경
- FindTotalEmotionResponse DTO에서 감정 리스트만 응답했던 것을 그룹 이름도 같이 조회되도록 수정